### PR TITLE
Preserve Locale.US and Locale.ENGLISH in case conversions (T258926278)

### DIFF
--- a/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/conversions/BuiltinMembersConversion.kt
+++ b/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/conversions/BuiltinMembersConversion.kt
@@ -304,9 +304,7 @@ private class ConversionsHolder(private val symbolProvider: JKSymbolProvider, pr
     }
 
     private val neutralLocaleFQNames: List<String> = listOf(
-        "java.util.Locale.ROOT",
-        "java.util.Locale.US",
-        "java.util.Locale.ENGLISH"
+        "java.util.Locale.ROOT"
     )
 
     private val primitiveConversions: List<Conversion> = listOf(

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/caseConversion/stringCaseConversion.kt
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/caseConversion/stringCaseConversion.kt
@@ -7,8 +7,8 @@ internal class A {
         s.uppercase(Locale.getDefault())
         s.uppercase()
         s.uppercase(Locale.FRENCH)
-        s.uppercase()
-        s.uppercase()
+        s.uppercase(Locale.US)
+        s.uppercase(Locale.ENGLISH)
     }
 
     fun toLowerCase() {
@@ -17,7 +17,7 @@ internal class A {
         s.lowercase(Locale.getDefault())
         s.lowercase()
         s.lowercase(Locale.FRENCH)
-        s.lowercase()
-        s.lowercase()
+        s.lowercase(Locale.US)
+        s.lowercase(Locale.ENGLISH)
     }
 }


### PR DESCRIPTION
J2K treated Locale.US and Locale.ENGLISH as neutral locales equivalent to Locale.ROOT, dropping them during toLowerCase/toUpperCase conversion. This produced lowercase()/uppercase() with no argument, which uses Locale.ROOT semantics — not the same as Locale.US in Turkish locales where 'I'.lowercase() produces dotless-i instead of 'i'.

Fix: remove Locale.US and Locale.ENGLISH from neutralLocaleFQNames, keeping only Locale.ROOT (which genuinely matches Kotlin's parameterless lowercase()/uppercase() behavior).