### PR TITLE
Fix mangled type arguments in unresolved method calls (T240133299)

### DIFF
--- a/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/JKSymbolProvider.kt
+++ b/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/JKSymbolProvider.kt
@@ -56,7 +56,10 @@ class JKSymbolProvider(private val resolver: JKResolver) {
         if (target != null) return provideDirectSymbol(target) as T
         val unresolvedSymbol =
             if (isAssignable<T, JKUnresolvedField>()) JKUnresolvedField(reference.canonicalText, typeFactory)
-            else JKUnresolvedMethod(reference, typeFactory)
+            else JKUnresolvedMethod(
+                (reference as? PsiReferenceExpression)?.referenceName ?: reference.canonicalText,
+                typeFactory
+            )
         return unresolvedSymbol as T
     }
 

--- a/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/JavaToJKTreeBuilder.kt
+++ b/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/JavaToJKTreeBuilder.kt
@@ -344,7 +344,7 @@ class JavaToJKTreeBuilder(
             }
             val symbol = target?.let {
                 symbolProvider.provideDirectSymbol(it)
-            } ?: JKUnresolvedMethod(methodExpression, typeFactory)
+            } ?: JKUnresolvedMethod(methodExpression.referenceName ?: methodExpression.canonicalText, typeFactory)
 
             return when {
                 methodExpression.referenceNameElement is PsiKeyword -> {
@@ -356,7 +356,7 @@ class JavaToJKTreeBuilder(
                     val calleeSymbol = when {
                         symbol is JKMethodSymbol -> symbol
                         target is KtLightMethod -> KtClassImplicitConstructorSymbol(target, typeFactory)
-                        else -> JKUnresolvedMethod(methodExpression, typeFactory)
+                        else -> JKUnresolvedMethod(methodExpression.referenceName ?: methodExpression.canonicalText, typeFactory)
                     }
                     JKDelegationConstructorCall(calleeSymbol, callee, arguments.toJK())
                 }


### PR DESCRIPTION
Use referenceName instead of canonicalText when creating JKUnresolvedMethod, so explicit type arguments like ImmutableSet.<UserKey>of() don't get embedded in the method name and rendered twice.