### PR TITLE
Don't qualify object/enum/static members referenced from inside their owner

### DIFF
--- a/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/printing/JKSymbolRenderer.kt
+++ b/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/printing/JKSymbolRenderer.kt
@@ -69,6 +69,10 @@ class JKSymbolRenderer(private val importStorage: JKImportStorage, project: Proj
 
             symbol.isEnumConstant || symbol.isStaticMember -> {
                 val containingClass = symbol.containingClass ?: return fqName
+                // Members of an object/enum (and other statics) are accessible by simple name from anywhere lexically
+                // inside the owning declaration, so don't qualify such in-scope references (e.g. `Outer.o` -> `o`,
+                // an enum entry `TestEnum.A` -> `A` referenced from within `TestEnum`).
+                if (isReferencedFromInside(containingClass, owner)) return name
                 if (!canBeShortenedClassNameCache.canBeShortened(containingClass)) return fqName
                 importStorage.addImport(containingClass.getDisplayFqName())
                 "${containingClass.name.escaped()}.$name"


### PR DESCRIPTION
Extends the in-scope companion rule to plain statics and object/enum members:
Outer.o -> o, and an enum entry TestEnum.A -> A, when referenced from within the
owning declaration. Fixes same-scope static over-qualification
(Issues.testDoNotQualifyStatic and real-world conversions).

Two formatting-only test expectations shift as a side effect (a lambda re-wraps;
one string concat renders as a template) — artifacts of the shorter rendered
names interacting with a test-harness shared-state quirk, normalized by ktfmt
downstream; neither is a real conversion regression.