### PR TITLE
Handle KtPropertyAccessor in JKSymbolProvider — fix J2K conversion crash

### DIFF
--- a/plugins/kotlin/j2k/k1.new/tests/test/org/jetbrains/kotlin/nj2k/K1JavaToKotlinConverterSingleFileTestGenerated.java
+++ b/plugins/kotlin/j2k/k1.new/tests/test/org/jetbrains/kotlin/nj2k/K1JavaToKotlinConverterSingleFileTestGenerated.java
@@ -2032,6 +2032,11 @@ public abstract class K1JavaToKotlinConverterSingleFileTestGenerated extends Abs
             runTest("../../shared/tests/testData/newJ2k/detectProperties/kt-32253.java");
         }
 
+        @TestMetadata("MergedPropertyReceiverShadowedByParam.java")
+        public void testMergedPropertyReceiverShadowedByParam() throws Exception {
+            runTest("../../shared/tests/testData/newJ2k/detectProperties/MergedPropertyReceiverShadowedByParam.java");
+        }
+
         @TestMetadata("NoBackingField.java")
         public void testNoBackingField() throws Exception {
             runTest("../../shared/tests/testData/newJ2k/detectProperties/NoBackingField.java");
@@ -4274,6 +4279,11 @@ public abstract class K1JavaToKotlinConverterSingleFileTestGenerated extends Abs
             runTest("../../shared/tests/testData/newJ2k/kotlinApiAccess/Property2.java");
         }
 
+        @TestMetadata("PropertyWithCustomAccessor.java")
+        public void testPropertyWithCustomAccessor() throws Exception {
+            runTest("../../shared/tests/testData/newJ2k/kotlinApiAccess/PropertyWithCustomAccessor.java");
+        }
+
         @TestMetadata("StaticImportAllFromFileFacade.java")
         public void testStaticImportAllFromFileFacade() throws Exception {
             runTest("../../shared/tests/testData/newJ2k/kotlinApiAccess/StaticImportAllFromFileFacade.java");
@@ -5761,6 +5771,11 @@ public abstract class K1JavaToKotlinConverterSingleFileTestGenerated extends Abs
         @TestMetadata("ConflictParameterName.java")
         public void testConflictParameterName() throws Exception {
             runTest("../../shared/tests/testData/newJ2k/overloads/ConflictParameterName.java");
+        }
+
+        @TestMetadata("ConflictParameterNameNestedCall.java")
+        public void testConflictParameterNameNestedCall() throws Exception {
+            runTest("../../shared/tests/testData/newJ2k/overloads/ConflictParameterNameNestedCall.java");
         }
 
         @TestMetadata("Override.java")

--- a/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/JKSymbolProvider.kt
+++ b/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/JKSymbolProvider.kt
@@ -172,6 +172,7 @@ class JKSymbolProvider(private val resolver: JKResolver) {
         is PsiField -> JKMultiverseFieldSymbol(psi, typeFactory)
         is KtFunction -> JKMultiverseFunctionSymbol(psi, typeFactory)
         is KtProperty -> JKMultiversePropertySymbol(psi, typeFactory)
+        is KtPropertyAccessor -> JKMultiversePropertySymbol(psi.property, typeFactory)
         is KtParameter -> JKMultiversePropertySymbol(psi, typeFactory)
         is PsiParameter -> JKMultiverseFieldSymbol(psi, typeFactory)
         is PsiLocalVariable -> JKMultiverseFieldSymbol(psi, typeFactory)

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/kotlinApiAccess/PropertyWithCustomAccessor.java
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/kotlinApiAccess/PropertyWithCustomAccessor.java
@@ -1,0 +1,8 @@
+// !ADD_KOTLIN_API
+import kotlinApi.KotlinClassWithProperties;
+
+class C {
+    void foo(KotlinClassWithProperties obj) {
+        obj.setSomeVar4(obj.getSomeVar4());
+    }
+}

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/kotlinApiAccess/PropertyWithCustomAccessor.kt
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/kotlinApiAccess/PropertyWithCustomAccessor.kt
@@ -1,0 +1,7 @@
+import kotlinApi.KotlinClassWithProperties
+
+internal class C {
+    fun foo(obj: KotlinClassWithProperties) {
+        obj.someVar4 = obj.someVar4
+    }
+}


### PR DESCRIPTION
J2K crashed with IllegalStateException: Unexpected argument type:
org.jetbrains.kotlin.psi.KtPropertyAccessor when a Java reference resolved to a
Kotlin property's custom getter/setter (e.g. calling getX()/setX() on a Kotlin
var that declares a custom accessor). createDirectSymbol had no branch for
KtPropertyAccessor, so it hit the error() fallback and the whole file failed to
convert (No kotlin files converted). T278835748.

Map a KtPropertyAccessor to a property symbol for its containing property, so
the accessor reference converts to property access. Adds regression test
PropertyWithCustomAccessor (K1).