### PR TITLE
Don't rebind a setter-call assignment to `this` inside anonymous classes

### DIFF
--- a/plugins/kotlin/j2k/k1.new.post-processing/src/org/jetbrains/kotlin/idea/j2k/post/processing/processings/K1ConvertGettersAndSettersToPropertyProcessing.kt
+++ b/plugins/kotlin/j2k/k1.new.post-processing/src/org/jetbrains/kotlin/idea/j2k/post/processing/processings/K1ConvertGettersAndSettersToPropertyProcessing.kt
@@ -763,7 +763,15 @@ private class ClassConverter(
                         psiFactory.createExpression("${qualifier.receiverExpression.text}.$propertyName = ${newValue.text}")
                     )
                 } else {
-                    callExpression.replace(psiFactory.createExpression("this.$propertyName = ${newValue.text}"))
+                    // The original call was unqualified. When it is inside a nested/anonymous class,
+                    // a hardcoded `this.` would rebind to that inner class instead of the property's
+                    // owner (breaking resolution), so emit the assignment unqualified — it resolves
+                    // through the implicit enclosing receiver. Within the property's own class keep the
+                    // explicit `this.` to preserve disambiguation from a shadowing local.
+                    val ownerClass = ktProperty.getStrictParentOfType<KtClassOrObject>()
+                    val callSiteClass = callExpression.getStrictParentOfType<KtClassOrObject>()
+                    val receiverPrefix = if (callSiteClass != null && callSiteClass != ownerClass) "" else "this."
+                    callExpression.replace(psiFactory.createExpression("$receiverPrefix$propertyName = ${newValue.text}"))
                 }
             }
         } else {

--- a/plugins/kotlin/j2k/k1.new/tests/test/org/jetbrains/kotlin/nj2k/K1JavaToKotlinConverterSingleFileTestGenerated.java
+++ b/plugins/kotlin/j2k/k1.new/tests/test/org/jetbrains/kotlin/nj2k/K1JavaToKotlinConverterSingleFileTestGenerated.java
@@ -6664,6 +6664,11 @@ public abstract class K1JavaToKotlinConverterSingleFileTestGenerated extends Abs
             runTest("../../shared/tests/testData/newJ2k/thisExpression/classAdotThisFoo.java");
         }
 
+        @TestMetadata("setterInlinedIntoAnonymousClass.java")
+        public void testSetterInlinedIntoAnonymousClass() throws Exception {
+            runTest("../../shared/tests/testData/newJ2k/thisExpression/setterInlinedIntoAnonymousClass.java");
+        }
+
         @TestMetadata("thisStatement.java")
         public void testThisStatement() throws Exception {
             runTest("../../shared/tests/testData/newJ2k/thisExpression/thisStatement.java");

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/thisExpression/setterInlinedIntoAnonymousClass.java
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/thisExpression/setterInlinedIntoAnonymousClass.java
@@ -1,0 +1,36 @@
+package test;
+
+public class Manager {
+  private boolean mEnabled;
+
+  public boolean getIsEnabled() {
+    return mEnabled;
+  }
+
+  private void setIsEnabled(boolean enabled) {
+    this.mEnabled = enabled;
+  }
+
+  interface Callback {
+    void onSuccess(boolean b);
+
+    void onFail();
+  }
+
+  void register(Callback c) {}
+
+  void make() {
+    register(
+        new Callback() {
+          @Override
+          public void onSuccess(boolean b) {
+            setIsEnabled(b);
+          }
+
+          @Override
+          public void onFail() {
+            setIsEnabled(false);
+          }
+        });
+  }
+}

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/thisExpression/setterInlinedIntoAnonymousClass.kt
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/thisExpression/setterInlinedIntoAnonymousClass.kt
@@ -1,0 +1,27 @@
+package test
+
+class Manager {
+    var isEnabled: Boolean = false
+        private set
+
+    interface Callback {
+        fun onSuccess(b: Boolean)
+
+        fun onFail()
+    }
+
+    fun register(c: Callback?) {}
+
+    fun make() {
+        register(
+            object : Callback {
+                override fun onSuccess(b: Boolean) {
+                    isEnabled = b
+                }
+
+                override fun onFail() {
+                    isEnabled = false
+                }
+            })
+    }
+}


### PR DESCRIPTION
When ConvertGettersAndSettersToProperty merged a getter/setter+field into a
property, it rewrote unqualified setter calls (setX(v)) to `this.<prop> = v`.
Inside a multi-method anonymous class `this` binds to the anonymous object, not
the property's owner, so the assignment referenced a non-existent member
(Unresolved reference) and dragged in a stale field name. (Single-method
interfaces convert to lambdas, which don't rebind `this`, so only multi-method
anon classes hit it.) T278835237.

Emit the assignment unqualified when the call site is in a nested/anonymous
class (resolves through the implicit enclosing receiver); keep the explicit
`this.` within the property's own class to preserve shadowing disambiguation.
Adds regression test setterInlinedIntoAnonymousClass (K1).