### PR TITLE
Keep the enum class qualifier when converting values()[i] to entries

### DIFF
--- a/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/conversions/EnumSyntheticValuesMethodConversion.kt
+++ b/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/conversions/EnumSyntheticValuesMethodConversion.kt
@@ -51,10 +51,13 @@ class EnumSyntheticValuesMethodConversion(context: ConverterContext) : Recursive
             symbolProvider.provideFieldSymbol("${enumClassSymbol.fqName}.$ENUM_ENTRIES_PROPERTY_NAME")
         )
 
-        // When element is a JKCallExpression that is the selector of a parent JKQualifiedExpression,
+        // When element is a JKCallExpression that is the *selector* of a parent JKQualifiedExpression,
         // the parent already provides the enum class qualifier (e.g. OuterClass.InnerEnum.values()).
         // Just replace the call with the entries field access to avoid duplicating the qualifier.
-        val parentProvidesQualifier = element is JKCallExpression && element.parent is JKQualifiedExpression
+        // Note: element being the *receiver* of a chained call (e.g. `values()[i]` lowered to
+        // `values().get(i)`) does NOT provide a qualifier, so the enum class must still be prepended.
+        val parentProvidesQualifier =
+            element is JKCallExpression && (element.parent as? JKQualifiedExpression)?.selector == element
         val entriesCall = if (parentProvidesQualifier) {
             entriesField.withFormattingFrom(element)
         } else {


### PR DESCRIPTION
EnumSyntheticValuesMethodConversion treated any values() call whose parent is a
JKQualifiedExpression as already class-qualified and emitted a bare entries. But
when Enum.values()[i] is lowered to Enum.values().get(i), the values() call is
the *receiver* of that qualified expression, not the selector — no class
qualifier is present, so dropping it left an unresolved bare entries (for an
external enum: entries.get(1) instead of LibraryEnumKt.entries[1]).

Only treat the parent as providing the qualifier when the call is the parent's
selector. Fixes Enum.testEnumValuesWithExternalKotlinLibrary.