### PR TITLE
Fix DefaultArguments conversion crash on nested self-receiver calls

### DIFF
--- a/plugins/kotlin/j2k/k2/tests/test/org/jetbrains/kotlin/j2k/k2/K2JavaToKotlinConverterSingleFileTestGenerated.java
+++ b/plugins/kotlin/j2k/k2/tests/test/org/jetbrains/kotlin/j2k/k2/K2JavaToKotlinConverterSingleFileTestGenerated.java
@@ -5763,6 +5763,11 @@ public abstract class K2JavaToKotlinConverterSingleFileTestGenerated extends Abs
             runTest("../../shared/tests/testData/newJ2k/overloads/ConflictParameterName.java");
         }
 
+        @TestMetadata("ConflictParameterNameNestedCall.java")
+        public void testConflictParameterNameNestedCall() throws Exception {
+            runTest("../../shared/tests/testData/newJ2k/overloads/ConflictParameterNameNestedCall.java");
+        }
+
         @TestMetadata("Override.java")
         public void testOverride() throws Exception {
             runTest("../../shared/tests/testData/newJ2k/overloads/Override.java");

--- a/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/conversions/DefaultArgumentsConversion.kt
+++ b/plugins/kotlin/j2k/shared/src/org/jetbrains/kotlin/nj2k/conversions/DefaultArgumentsConversion.kt
@@ -76,7 +76,10 @@ class DefaultArgumentsConversion(context: ConverterContext) : RecursiveConversio
                 }
 
                 on is JKCallExpression && on.identifier.needsExplicitThisReceiver() -> {
-                    val selector = applyRecursive(on, ::remapParameterSymbol)
+                    // Use a detached copy as the selector: `on` may still be attached to its parent
+                    // (applyRecursive returns it unchanged), and wrapping an already-attached node in a
+                    // new JKQualifiedExpression would violate the single-parent tree invariant.
+                    val selector = applyRecursive(on.copyTreeAndDetach(), ::remapParameterSymbol)
                     return JKQualifiedExpression(JKThisExpression(JKLabelEmpty(), JKNoType), selector)
                 }
             }

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/overloads/ConflictParameterNameNestedCall.java
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/overloads/ConflictParameterNameNestedCall.java
@@ -1,0 +1,13 @@
+public class Test {
+
+    private boolean c() {
+        return true;
+    }
+
+    public void foo() {
+        foo(!c());
+    }
+
+    public void foo(boolean c) {
+    }
+}

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/overloads/ConflictParameterNameNestedCall.k2.kt
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/overloads/ConflictParameterNameNestedCall.k2.kt
@@ -1,0 +1,9 @@
+class Test {
+    private fun c(): Boolean {
+        return true
+    }
+
+    @JvmOverloads
+    fun foo(c: Boolean = !this.c()) {
+    }
+}

--- a/plugins/kotlin/j2k/shared/tests/testData/newJ2k/overloads/ConflictParameterNameNestedCall.kt
+++ b/plugins/kotlin/j2k/shared/tests/testData/newJ2k/overloads/ConflictParameterNameNestedCall.kt
@@ -1,0 +1,9 @@
+class Test {
+    private fun c(): Boolean {
+        return true
+    }
+
+    @JvmOverloads
+    fun foo(c: Boolean = !c()) {
+    }
+}


### PR DESCRIPTION
When DefaultArgumentsConversion adds an explicit `this` receiver to a call that needs one, it wrapped the call node in a new JKQualifiedExpression while the node was still attached to its original parent (applyRecursive returns it unchanged). That violates the single-parent tree invariant and threw IllegalStateException, failing the whole file with "No kotlin files converted". Use a detached copy of the node as the selector instead.

Adds regression test ConflictParameterNameNestedCall (K1 + K2).